### PR TITLE
✨[feat]: 메세지 추가하기 플러스 버튼 white 색상 추가 제작

### DIFF
--- a/src/assets/icons/ic-plus.svg
+++ b/src/assets/icons/ic-plus.svg
@@ -1,4 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 1.71436V22.2858" stroke="white" stroke-width="3" stroke-linecap="round"/>
-<path d="M1.71387 12L22.2853 12" stroke="white" stroke-width="3" stroke-linecap="round"/>
+<path d="M12 1.71436V22.2858" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+<path d="M1.71387 12L22.2853 12" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/components/common/Button/index.module.css
+++ b/src/components/common/Button/index.module.css
@@ -184,7 +184,7 @@
   color: var(--gray-500);
 }
 
-/* 메세지 추가에 쓰는 플러스 버튼 */
+/* 메세지 추가에 쓰는 플러스 버튼(컬러 배경용) */
 .variantCircle {
   width: max-content;
   flex-direction: column;
@@ -234,6 +234,58 @@
 .variantCircle:disabled .leftIcon:hover {
   cursor: not-allowed;
   background-color: var(--gray-300);
+}
+
+/* 메세지 추가에 쓰는 플러스 버튼(이미지 배경용) */
+.variantWhiteCircle {
+  width: max-content;
+  flex-direction: column;
+  justify-content: flex-start;
+  border: none;
+  color: var(--white);
+  cursor: pointer;
+  background: transparent;
+  padding: 0;
+  height: auto;
+  border-radius: 0;
+  transition:
+    transform 0.15s ease,
+    background-color 0.15s ease;
+}
+.variantWhiteCircle .leftIcon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.variantWhiteCircle .leftIcon svg {
+  width: 28px;
+  height: 28px;
+  color: var(--gray-200);
+}
+.variantWhiteCircle .label {
+  white-space: nowrap;
+  font-size: 16px;
+  font-weight: var(--font-weight-bold);
+  color: var(--white);
+  line-height: 1.2;
+  margin-top: 24px;
+}
+.variantWhiteCircle .leftIcon:hover {
+  background: var(--gray-100);
+}
+.variantWhiteCircle:active {
+  transform: translateY(0);
+}
+.variantWhiteCircle:disabled {
+  cursor: not-allowed;
+}
+.variantWhiteCircle:disabled .leftIcon:hover {
+  cursor: not-allowed;
+  background-color: var(--gray-100);
 }
 
 /* 화살표 버튼 */


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #80 

## 📝작업 내용

> 메세지 추가하기 (+) 버튼을 하얀색 버전으로도 제작했습니다.
> 이미지 배경 선택 시 사용될 예정입니다.

### 스크린샷 (선택)

<img width="268" height="167" alt="image" src="https://github.com/user-attachments/assets/71f78772-78ac-4ea3-9be7-3869f9a39226" />

<img width="118" height="116" alt="image" src="https://github.com/user-attachments/assets/89ddc050-ad13-465d-9734-94c9a53b4b1d" />


### 추가한 라이브러리

## 💬리뷰 요구사항(선택)
