### PR TITLE
Fix/#116 롤링 페이지 작성 페이지, 메세지 작성 페이지 너비/여백 통일

### DIFF
--- a/src/pages/MessagePage/index.module.css
+++ b/src/pages/MessagePage/index.module.css
@@ -5,7 +5,7 @@
   padding: 64px 24px;
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 64px;
 }
 
 .section {
@@ -37,5 +37,6 @@
 @media screen and (max-width: 767px) {
   .messagePage {
     padding: 48px 24px;
+    gap: 48px;
   }
 }

--- a/src/pages/PostPage/index.module.css
+++ b/src/pages/PostPage/index.module.css
@@ -5,7 +5,7 @@
   padding: 64px 24px;
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 64px;
 }
 
 .section {
@@ -50,5 +50,6 @@
 @media screen and (max-width: 767px) {
   .postPage {
     padding: 48px 24px;
+    gap: 48px;
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #116 

## 📝작업 내용

> 롤링 페이지 작성 페이지, 메세지 작성 페이지 너비/여백 통일
- 최대 너비 768px
- padding : PC&테블릿  64px 24px /  모바일 48px 24px 
- gap : PC&테블릿 64px / 모바일 48px

### 스크린샷 (선택)

<img width="1424" height="732" alt="image" src="https://github.com/user-attachments/assets/ec87ce40-4c08-49a7-ab75-cb0140ceae6e" />
<img width="1427" height="656" alt="image" src="https://github.com/user-attachments/assets/c589167d-4eef-449b-a3b6-e1c78fe95111" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
