### PR TITLE
Fix/#118 이모지 검색 한국어, 영어 모두 허용

### DIFF
--- a/.github/workflows/vercel-preview-comment.yml
+++ b/.github/workflows/vercel-preview-comment.yml
@@ -30,8 +30,9 @@ jobs:
               'geniexx64',
               'ziy1027',
             ]);
+            const allowedBases = new Set(['develop', 'release']);
             const allowed =
-              base === 'develop' &&
+              allowedBases.has(base) &&
               labels.includes('🔎 Preview') &&
               allowedAuthors.has(author);
             core.setOutput('allowed', allowed ? 'true' : 'false');

--- a/src/components/reaction/EmojiPickerPopup/index.jsx
+++ b/src/components/reaction/EmojiPickerPopup/index.jsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import EmojiPicker from 'emoji-picker-react';
 import { createPortal } from 'react-dom';
+import mergedEmojiData from '@/utils/emojiData';
 import styles from './index.module.css';
 
 const ANCHOR_GAP = 8;
@@ -145,9 +146,9 @@ export default function EmojiPickerPopup({ open, onClose, onPick, anchorRef }) {
       style={{ top: pos.top, left: pos.left }}
     >
       <EmojiPicker
-        // 이모지 문자열은 emojiData.emoji
         onEmojiClick={(emojiData) => onPick(emojiData.emoji)}
-        searchPlaceholder="Search"
+        emojiData={mergedEmojiData}
+        searchPlaceholder="검색 / Search"
         skinTonesDisabled
         previewConfig={{ showPreview: false }}
       />

--- a/src/utils/emojiData.js
+++ b/src/utils/emojiData.js
@@ -51,11 +51,7 @@ const mergedEmojiData = (() => {
         return;
       }
 
-      names.forEach((name) => {
-        if (!target.n.includes(name)) {
-          target.n.push(name);
-        }
-      });
+      target.n = [...new Set([...target.n, ...names])];
     });
   });
 

--- a/src/utils/emojiData.js
+++ b/src/utils/emojiData.js
@@ -1,0 +1,65 @@
+/**
+ * en / ko 이모지 검색 데이터를 병합해
+ * 영문 + 한글 키워드가 동시에 검색 가능한
+ * 단일 searchData를 생성
+ *
+ * - en 데이터를 기준(base)으로 사용
+ * - 같은 이모지는 unicode(u) 값을 기준으로 매칭
+ * - ko의 name(n) 배열을 en의 name(n)에 병합
+ */
+
+import en from 'emoji-picker-react/dist/data/emojis-en';
+import ko from 'emoji-picker-react/dist/data/emojis-ko';
+
+const EMOJI_SEARCH_DATA = {
+  ko,
+  en,
+};
+
+const mergedEmojiData = (() => {
+  const baseIndex = new Map();
+  const merged = {
+    categories: EMOJI_SEARCH_DATA.en.categories,
+    emojis: {},
+  };
+
+  Object.entries(EMOJI_SEARCH_DATA.en.emojis).forEach(([category, list]) => {
+    merged.emojis[category] = list.map((emoji) => {
+      const names = Array.isArray(emoji.n) ? [...emoji.n] : [];
+      const next = { ...emoji, n: names };
+      if (next.u) {
+        baseIndex.set(next.u, next);
+      }
+      return next;
+    });
+  });
+
+  Object.entries(EMOJI_SEARCH_DATA.ko.emojis).forEach(([category, list]) => {
+    const targetList = merged.emojis[category];
+    if (!targetList) {
+      return;
+    }
+
+    list.forEach((emoji) => {
+      const names = emoji?.n;
+      if (!emoji?.u || !Array.isArray(names)) {
+        return;
+      }
+
+      const target = baseIndex.get(emoji.u);
+      if (!target) {
+        return;
+      }
+
+      names.forEach((name) => {
+        if (!target.n.includes(name)) {
+          target.n.push(name);
+        }
+      });
+    });
+  });
+
+  return merged;
+})();
+
+export default mergedEmojiData;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #118 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**emoji-picker-react**
- 한국어/영어 모두지원
- en / ko 이모지 검색 데이터를 병합해 영문 + 한글 키워드가 동시에 검색 가능한 단일 searchData를 생성해서 구현
- en 데이터를 기준(base)으로 사용/같은 이모지는 unicode(u) 값을 기준으로 매칭/ ko의 name(n) 배열을 en의 name(n)에 병합

예시
`{
  u: "1F600",
  n: ["smile", "grin", "웃음", "미소"]
}
`
### 스크린샷 (선택)

<img width="349" height="215" alt="image" src="https://github.com/user-attachments/assets/58b07cdc-221e-41ec-99a5-67e65d786bc1" />
<img width="350" height="224" alt="image" src="https://github.com/user-attachments/assets/848a907a-c774-4e00-865c-e085779acd52" />

### 추가한 라이브러리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

⚠️ moji-picker-react는 multi-language search를 공식 지원하지 않아서 라이브러리 업데이트 시 깨질 수도 있음