### PR TITLE
🐛[fix]: 메세지모달 모바일 반응형에서 양쪽 여백 추가

### DIFF
--- a/src/components/modal/MessageModal/index.module.css
+++ b/src/components/modal/MessageModal/index.module.css
@@ -83,9 +83,15 @@
   justify-content: flex-end;
 }
 
-/* 모바일 전용 스타일 */
+/* 태블릿 전용 스타일 */
 @media screen and (max-width: 767px) {
   .modalContent {
     width: 327px;
+  }
+}
+
+@media screen and (max-width: 413px) {
+  .modalContent {
+    width: 250px;
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #120 

## 📝작업 내용

> 메세지 모달 모바일 반응형에서 양쪽 여백 추가

### 스크린샷 (선택)

<img width="356" height="559" alt="image" src="https://github.com/user-attachments/assets/0b5094d6-34dc-44bc-b56f-b3cb308afc3f" />


### 추가한 라이브러리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
