### PR TITLE
Fix/#124 메세지 모달에서 HTML 태그 노출 수정

### DIFF
--- a/.github/workflows/vercel-preview-comment.yml
+++ b/.github/workflows/vercel-preview-comment.yml
@@ -30,9 +30,7 @@ jobs:
               'geniexx64',
               'ziy1027',
             ]);
-            const allowedBases = new Set(['develop', 'release']);
             const allowed =
-              allowedBases.has(base) &&
               labels.includes('🔎 Preview') &&
               allowedAuthors.has(author);
             core.setOutput('allowed', allowed ? 'true' : 'false');

--- a/src/components/list-detail/MessageWrap/index.jsx
+++ b/src/components/list-detail/MessageWrap/index.jsx
@@ -91,6 +91,7 @@ function MessageWrap({
           relationship={selectedMessage.relationship}
           date={formatDate(selectedMessage.createdAt)}
           content={selectedMessage.content}
+          font={selectedMessage.font}
         />
       )}
     </>

--- a/src/components/modal/MessageModal/index.jsx
+++ b/src/components/modal/MessageModal/index.jsx
@@ -5,6 +5,8 @@ import Modal from '@/components/modal/Modal';
 import Button from '@/components/common/Button';
 import ProfileImage from '@/components/common/ProfileImage';
 import RelationshipBadge from '@/components/common/RelationshipBadge';
+import EditorViewer from '@/components/message/EditorViewer';
+import { FONT_MAP } from '@/constants/editor';
 
 export default function MessageModal({
   isOpen,
@@ -15,11 +17,14 @@ export default function MessageModal({
   relationship,
   date,
   content,
+  font,
 }) {
   const handleConfirm = () => {
     onConfirm?.();
     onClose();
   };
+
+  const safeFont = FONT_MAP[font] ?? 'inherit';
 
   return (
     <Modal
@@ -53,7 +58,9 @@ export default function MessageModal({
           </div>
         </header>
 
-        <div className={styles.modalContent}>{content}</div>
+        <div className={styles.modalContent} style={{ fontFamily: safeFont }}>
+          <EditorViewer content={content} currentFont={safeFont} />
+        </div>
 
         <div className={styles.actions}>
           <Button
@@ -78,6 +85,7 @@ MessageModal.propTypes = {
   relationship: PropTypes.oneOf(['지인', '동료', '가족', '친구']).isRequired,
   date: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
+  font: PropTypes.string,
 };
 
 MessageModal.defaultProps = {


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #124

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 메세지 모달에서 HTML 태그가 보이는 문제 해결
- font랑 editor viewer 적용

### 스크린샷 (선택)
<img width="517" height="424" alt="image" src="https://github.com/user-attachments/assets/44b0e37a-8fc1-4c41-9dbb-33922f655623" />

### 추가한 라이브러리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
