### PR TITLE
🐛[fix]: 모바일에서 이모지 더보기 박스 잘림 현상 처리

### DIFF
--- a/src/components/reaction/ReactionPanel/index.module.css
+++ b/src/components/reaction/ReactionPanel/index.module.css
@@ -139,7 +139,7 @@
 }
 
 /* 모바일 전용 스타일 */
-@media screen and (max-width: 413px) {
+@media screen and (max-width: 768px) {
   .panel {
     left: auto;
     right: 0;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #132 

## 📝작업 내용

> 모바일 해상도에서 이모지 더보기 박스 잘림 현상 처리

### 스크린샷 (선택)

<img width="343" height="598" alt="image" src="https://github.com/user-attachments/assets/131818d0-9ec8-4e9a-8509-691c2fe58ef3" />


### 추가한 라이브러리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
