### PR TITLE
🐛[fix]: 리액션 더보기 박스 외에 다른곳 클릭 시 닫히도록 수정

### DIFF
--- a/src/components/list-detail/RollingHeader/index.jsx
+++ b/src/components/list-detail/RollingHeader/index.jsx
@@ -46,6 +46,10 @@ function RollingHeader({
   const handleEdit = () => setIsEditMode(true);
   const handleSave = () => setIsEditMode(false);
 
+  const handlePanelClose = useCallback(() => {
+    setIsPanelOpen(false);
+  }, []);
+
   const fetchReactions = useCallback(async () => {
     if (!id) {
       return;
@@ -213,7 +217,7 @@ function RollingHeader({
                 <ReactionPanel
                   reactions={reactionsObject}
                   onItemClick={handleEmojiClick}
-                  onClose={() => setIsPanelOpen(false)}
+                  onClose={handlePanelClose}
                 />
               )}
             </div>

--- a/src/components/reaction/ReactionPanel/index.jsx
+++ b/src/components/reaction/ReactionPanel/index.jsx
@@ -16,13 +16,9 @@ export default function ReactionPanel({ reactions, onItemClick, onClose }) {
   const entries = Object.entries(reactions).sort((a, b) => b[1] - a[1]);
 
   useEffect(() => {
-    const handleMouseDown = (e) => {
-      if (!panelRef.current) {
-        return;
-      }
-
-      // 패널 안을 클릭한 게 아니라면 닫기
-      if (!panelRef.current.contains(e.target)) {
+    const handlePointerDown = (e) => {
+      // 패널(ref)이 존재하고, 클릭한 대상이 패널 내부에 있지 않을 때만 onClose 호출
+      if (panelRef.current && !panelRef.current.contains(e.target)) {
         onClose?.();
       }
     };
@@ -33,11 +29,11 @@ export default function ReactionPanel({ reactions, onItemClick, onClose }) {
       }
     };
 
-    document.addEventListener('mousedown', handleMouseDown);
+    document.addEventListener('pointerdown', handlePointerDown);
     document.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      document.removeEventListener('mousedown', handleMouseDown);
+      document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [onClose]);


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #136 

## 📝작업 내용

> 리액션 더보기 박스 외에 다른 곳 클릭 시 닫히도록 수정 (이모지 피커 모달과 중첩 방지)

### 스크린샷 (선택)

### 추가한 라이브러리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
