### PR TITLE
Fix/#131 메시지 삭제 시 프로필 그룹 동기화

### DIFF
--- a/src/pages/ListDetailPage/index.jsx
+++ b/src/pages/ListDetailPage/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import styles from './index.module.css';
 import PropTypes from 'prop-types';
@@ -33,6 +33,12 @@ function ListDetailPage() {
   const [hasNext, setHasNext] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const observerTarget = useRef(null);
+  const messageCount = messages.length;
+  const recentMessages = useMemo(() => {
+    return [...messages]
+      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+      .slice(0, 3);
+  }, [messages]);
 
   const handleClickDeleteRecipient = () => {
     setIsRecipientModalOpen(true);
@@ -200,12 +206,12 @@ function ListDetailPage() {
         <RollingHeader
           theme={theme}
           recipientName={recipient.name}
-          messageCount={recipient.messageCount}
-          recentMessages={recipient.recentMessages}
+          messageCount={messageCount}
+          recentMessages={recentMessages}
           topReactions={recipient.topReactions}
           isEditMode={isEditMode}
           setIsEditMode={setIsEditMode}
-          hasMessages={recipient.messageCount > 0}
+          hasMessages={messageCount > 0}
           onDelete={handleClickDeleteRecipient}
         />
 

--- a/src/pages/ListDetailPage/index.jsx
+++ b/src/pages/ListDetailPage/index.jsx
@@ -36,7 +36,7 @@ function ListDetailPage() {
   const messageCount = messages.length;
   const recentMessages = useMemo(() => {
     return [...messages]
-      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+      .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0))
       .slice(0, 3);
   }, [messages]);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #131 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

메시지 삭제 시 프로필 그룹이 바로 갱신되도록 상태 동기화를 단순화했습니다.
- 상세 페이지에서 messages 하나로 관리
- 프로필 그룹(작성자 변경 기준)과 작성자 수는 messages를 기반으로 따로 저장하지 않고 계산해서 사용하도록 변경
- 메시지 추가/삭제 시에도 프로필 그룹 UI가 자동으로 함께 갱신되도록 했습니다.

### 스크린샷 (선택)

### 추가한 라이브러리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
