### PR TITLE
🐛[fix]: 인기 롤링 페이퍼 슬라이드 높이 조절

### DIFF
--- a/src/components/common/ProfileGroup/index.module.css
+++ b/src/components/common/ProfileGroup/index.module.css
@@ -2,6 +2,7 @@
   display: inline-flex;
   align-items: center;
   gap: 12px;
+  height: 36px;
 }
 
 .profileGroup {
@@ -36,10 +37,11 @@
 
 .writerCount {
   font-weight: var(--font-weight-regular);
-  font-size: 18px;
-  line-height: 1;
+  font-size: 14px;
+  line-height: 1.3;
+  word-break: auto-phrase;
 }
 
-.countBold{
+.countBold {
   font-weight: var(--font-weight-bold);
 }

--- a/src/components/list/PopularRolling/index.module.css
+++ b/src/components/list/PopularRolling/index.module.css
@@ -5,6 +5,7 @@
 
 .rollingSwiper {
   position: relative;
+  align-items: stretch;
 }
 
 .swiperArrowButtons {

--- a/src/components/list/RollingCard/index.module.css
+++ b/src/components/list/RollingCard/index.module.css
@@ -11,11 +11,13 @@
   font-family: Poppins, 'Pretendard Variable', Pretendard;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   aspect-ratio: 1 / 1;
   background-color: var(--bg);
   padding: 24px;
   cursor: pointer;
+  height: 100%;
+  width: 100%;
 }
 
 .rollingCard > * {


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #145 

## 📝작업 내용

> 인기 롤링페이퍼 슬라이드 높이 맞춤

### 스크린샷 (선택)
<img width="850" height="600" alt="image" src="https://github.com/user-attachments/assets/3242b11f-402a-40c6-a00b-d53f36a573e0" />

### 추가한 라이브러리

## 💬리뷰 요구사항(선택)
