### PR TITLE
Fix/#156 대상 찾기 에러 -> 에러토스트로 변경

### DIFF
--- a/src/pages/ListDetailPage/index.jsx
+++ b/src/pages/ListDetailPage/index.jsx
@@ -116,6 +116,12 @@ function ListDetailPage() {
         }
       } catch (error) {
         console.error('데이터를 불러오는 중 에러 발생:', error);
+        const status = error?.response?.status;
+        if (status === 404) {
+          showToast('대상을 찾을 수 없습니다.', 'error');
+          navigate('/list');
+          return;
+        }
         if (isRetryableError(error)) {
           setError(error);
         }
@@ -125,7 +131,7 @@ function ListDetailPage() {
     };
 
     fetchData();
-  }, [id]);
+  }, [id, navigate, showToast]);
 
   const handleLoadMore = useCallback(async () => {
     if (!hasNext || isLoadingMore || !id) {
@@ -154,13 +160,6 @@ function ListDetailPage() {
     hasNext,
     isLoading || isLoadingMore
   );
-
-  useEffect(() => {
-    if (!isLoading && !recipient && !error) {
-      showToast('대상을 찾을 수 없습니다.', 'error');
-      navigate('/list');
-    }
-  }, [isLoading, recipient, error, showToast, navigate]);
 
   if (error) {
     throw error;

--- a/src/pages/ListDetailPage/index.jsx
+++ b/src/pages/ListDetailPage/index.jsx
@@ -14,6 +14,7 @@ import {
 import ConfirmModal from '@/components/modal/ConfirmationModal';
 import isRetryableError from '@/utils/isRetryableError';
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
+import useToast from '@/hooks/useToast';
 
 const LIMIT = 8;
 
@@ -39,6 +40,7 @@ function ListDetailPage() {
       .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0))
       .slice(0, 3);
   }, [messages]);
+  const { showToast } = useToast();
 
   const handleClickDeleteRecipient = () => {
     setIsRecipientModalOpen(true);
@@ -153,6 +155,13 @@ function ListDetailPage() {
     isLoading || isLoadingMore
   );
 
+  useEffect(() => {
+    if (!isLoading && !recipient && !error) {
+      showToast('대상을 찾을 수 없습니다.', 'error');
+      navigate('/list');
+    }
+  }, [isLoading, recipient, error, showToast, navigate]);
+
   if (error) {
     throw error;
   }
@@ -160,7 +169,7 @@ function ListDetailPage() {
     return <div>로딩 중...</div>;
   }
   if (!recipient) {
-    return <div>대상을 찾을 수 없습니다.</div>;
+    return null;
   }
 
   const { backgroundColor, backgroundImageURL } = recipient;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #156 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**에러 토스트로 변경**
- 기존의 대상을 찾을 수 없습니다는 빈페이지의 텍스트로 화면에 표시됨
- 이를 에러토스트로 변경하고 /list 페이지로 이동하게 만들어 ux를 개선함

### 스크린샷 (선택)

### 추가한 라이브러리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
