### PR TITLE
Fix/#158 프로필 그룹 삭제 업데이트 수정

### DIFF
--- a/src/pages/ListDetailPage/index.jsx
+++ b/src/pages/ListDetailPage/index.jsx
@@ -114,7 +114,7 @@ function ListDetailPage() {
         setTotalCount(
           typeof recipientData.messageCount === 'number'
             ? recipientData.messageCount
-            : messagesData.results.length
+            : (messagesData.count ?? messagesData.results.length)
         );
 
         if (!messagesData.next) {

--- a/src/pages/ListDetailPage/index.jsx
+++ b/src/pages/ListDetailPage/index.jsx
@@ -24,6 +24,7 @@ function ListDetailPage() {
 
   const [recipient, setRecipient] = useState(null);
   const [messages, setMessages] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isEditMode, setIsEditMode] = useState(false);
   const [isRecipientModalOpen, setIsRecipientModalOpen] = useState(false);
@@ -34,7 +35,6 @@ function ListDetailPage() {
 
   const [hasNext, setHasNext] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const messageCount = messages.length;
   const recentMessages = useMemo(() => {
     return [...messages]
       .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0))
@@ -84,6 +84,7 @@ function ListDetailPage() {
       setMessages((prevMessages) =>
         prevMessages.filter((msg) => msg.id !== deleteTargetMessageId)
       );
+      setTotalCount((prev) => Math.max(0, prev - 1));
     } catch (error) {
       console.error(error);
       if (isRetryableError(error)) {
@@ -110,6 +111,11 @@ function ListDetailPage() {
         ]);
         setRecipient(recipientData);
         setMessages(messagesData.results);
+        setTotalCount(
+          typeof recipientData.messageCount === 'number'
+            ? recipientData.messageCount
+            : messagesData.results.length
+        );
 
         if (!messagesData.next) {
           setHasNext(false);
@@ -194,12 +200,12 @@ function ListDetailPage() {
         <RollingHeader
           theme={theme}
           recipientName={recipient.name}
-          messageCount={messageCount}
+          messageCount={totalCount}
           recentMessages={recentMessages}
           topReactions={recipient.topReactions}
           isEditMode={isEditMode}
           setIsEditMode={setIsEditMode}
-          hasMessages={messageCount > 0}
+          hasMessages={totalCount > 0}
           onDelete={handleClickDeleteRecipient}
         />
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #158 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**프로필 그룹 삭제시 업데이트 수정**
-  화면에 보여줄 메시지 목록은 messages에 따로 저장
- 작성자 수(전체 메시지 수)는 totalCount에 따로 저장
- 프로필 그룹(최근 3명)은 messages를 기준으로 계산


### 스크린샷 (선택)

### 추가한 라이브러리

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
